### PR TITLE
Setup organisation preset for renovate

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base", ":dependencyDashboard"],
+  "timezone": "Europe/London",
+  "schedule": "after 7am and before 11am every weekday",
+  "labels": ["dependencies"],
+  
+  "helmv3": {
+    "fileMatch": ["\\Chart.yaml$"],
+    "bumpVersion": "patch",
+    "registryAliases": {
+      "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
+    }
+  },
+  "regexManagers": [{
+    "fileMatch": ["^Dockerfile$"],
+    "matchStrings": [
+      "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sARG .*?_VERSION=(?<currentValue>.*)\\s"
+    ]
+  }]
+}


### PR DESCRIPTION
See https://docs.renovatebot.com/config-presets/#organization-level-presets

Will need to cleanup global.json later

This should mean onboarding PRs contain our default config