### PR TITLE
Try merge Jenkins controller PRs without platform automerge

### DIFF
--- a/renovate/flux.json
+++ b/renovate/flux.json
@@ -33,7 +33,6 @@
       "matchPackageNames": ["hmctspublic.azurecr.io/jenkins/jenkins"],
       "automerge": true,
       "automergeType": "pr",
-      "platformAutomerge": true,
       "automergeSchedule": ["before 8am every weekday"]
     }
   ],


### PR DESCRIPTION
this https://github.com/hmcts/sds-flux-config/pull/2963 was merged when it shouldn't have been

I guess automerge schedule might not work with platformAutomerge