### PR TITLE
Group flyway versions together

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -19,5 +19,13 @@
     "registryAliases": {
       "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
     }
-  }
+  },
+  "packageRules": [
+    {
+      "groupName": "flyway",
+      "matchPackagePatterns": [
+        "flyway"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Tested in https://github.com/hmcts/draft-store/commit/a07f578d86f888485c63c65a143bf4d4c383d87f

https://github.com/hmcts/draft-store/pull/1423

Flyway now has multiple projects that you need to use, and spring bom is downgrading the dependency on flyway-core so you need to specify both projects currently rather than just the postgres one.