### PR TITLE
Revert "Temporarily disable autoupdate till Java 21 upgrade done (#36)"

### DIFF
--- a/renovate/flux.json
+++ b/renovate/flux.json
@@ -31,8 +31,6 @@
     },
     {
       "matchPackageNames": ["hmctspublic.azurecr.io/jenkins/jenkins"],
-      "enabled": false,
-      "description": "Temporarily disabled until upgraded to Java 21 in DTSPO-17352",
       "automerge": true,
       "automergeType": "pr",
       "schedule": "before 6am every weekday",


### PR DESCRIPTION
This reverts commit ff1d25ad466d0bc23a0b3d0698e883d837ae1478.

### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
