### PR TITLE
Disable Renovate automerge for Xmas Change Freeze 24/25

### DIFF
--- a/renovate/automerge-all.json
+++ b/renovate/automerge-all.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "automerge": true,
+  "automerge": false,
   "automergeType": "pr",
   "platformAutomerge": true
 }

--- a/renovate/automerge-minor.json
+++ b/renovate/automerge-minor.json
@@ -6,7 +6,7 @@
         "minor",
         "patch"
       ],
-      "automerge": true,
+      "automerge": false,
       "automergeType": "pr"
     }
   ],


### PR DESCRIPTION
### Change description

- disable Renovate automerge for Christmas Change Freeze 2024/2025. 23rd Dec - 3rd Jan


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
