### PR TITLE
Update jenkins-packer rules

### DIFF
--- a/renovate/flux.json
+++ b/renovate/flux.json
@@ -27,7 +27,8 @@
       "matchPackageNames": ["hmcts/jenkins-packer"],
       "automerge": true,
       "automergeType": "pr",
-      "platformAutomerge": true
+      "platformAutomerge": true,
+      "allowedVersions": "<1.6.0"
     },
     {
       "matchPackageNames": ["hmctspublic.azurecr.io/jenkins/jenkins"],


### PR DESCRIPTION
### Jira link

[DTSPO-23931](https://tools.hmcts.net/jira/browse/DTSPO-23931)

### Change description

Adding config to limit jenkins-packer updates to certain versions
Config pulled from https://docs.renovatebot.com/configuration-options/#allowedversions

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
