### PR TITLE
Provide central actions template for publish to ado artifacts

### DIFF
--- a/workflow-templates/ado_artifacts_build.json
+++ b/workflow-templates/ado_artifacts_build.json
@@ -1,0 +1,13 @@
+{
+    "name": "Trigger ADO Artifact Build",
+    "description": "A workflow to build and publish to Azure DevOps Artifactory on new github tags",
+    "iconName": "hmcts-logotype-crest",
+    "categories": [
+        "Java",
+        "Deployment"
+    ],
+    "filePatterns": [
+        "build.gradle"
+    ]
+  }
+  

--- a/workflow-templates/ado_artifacts_build.yaml
+++ b/workflow-templates/ado_artifacts_build.yaml
@@ -1,0 +1,33 @@
+name: Publish to Azure Artifacts
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  PublishToAzureArtifacts:
+    runs-on: ubuntu-latest 
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'gradle'
+
+      - name: Publish to Azure DevOps Artifacts
+        run: |
+          ./gradlew publish
+        env:
+          AZURE_DEVOPS_ARTIFACT_USERNAME: ${{ secrets.AZURE_DEVOPS_ARTIFACT_USERNAME }}
+          AZURE_DEVOPS_ARTIFACT_TOKEN: ${{ secrets.AZURE_DEVOPS_ARTIFACT_TOKEN }}
+          RELEASE_VERSION: ${{ github.ref_name }}
+        shell: bash


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-24312

Adds tested github action worfklow as a centralised option for teams to consume, similar to how it was set up for Jitpack in the past: https://github.com/hmcts/rse-cft-lib/actions/new?category=owner and will make teams updates simpler.