### PR TITLE
Add preset to update CPP Terraform Key Vault Module

### DIFF
--- a/renovate/cpp-terraform-azurerm-key-vault.json
+++ b/renovate/cpp-terraform-azurerm-key-vault.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "description": "Automerge minor and patch updates for the key-vault Terraform module",
+      "description": "Automerge minor and patch updates for the CPP Terraform key-vault module",
       "matchDatasources": ["terraform-module"],
       "matchManagers": ["terraform"],
       "matchSourceUrls": ["https://github.com/hmcts/cpp-module-terraform-azurerm-key-vault"],
@@ -11,7 +11,7 @@
       "automergeType": "pr"
     },
     {
-      "description": "Create PRs for major updates to the key-vault Terraform module without automerging",
+      "description": "Create PRs for major updates to the CPP Terraform key-vault module without automerging",
       "matchDatasources": ["terraform-module"],
       "matchManagers": ["terraform"],
       "matchSourceUrls": ["https://github.com/hmcts/cpp-module-terraform-azurerm-key-vault"],

--- a/renovate/terraform-azurerm-key-vault.json
+++ b/renovate/terraform-azurerm-key-vault.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Automerge minor and patch updates for the key-vault Terraform module",
+      "matchDatasources": ["terraform-module"],
+      "matchManagers": ["terraform"],
+      "matchSourceUrls": ["https://github.com/hmcts/cpp-module-terraform-azurerm-key-vault"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "description": "Create PRs for major updates to the key-vault Terraform module without automerging",
+      "matchDatasources": ["terraform-module"],
+      "matchManagers": ["terraform"],
+      "matchSourceUrls": ["https://github.com/hmcts/cpp-module-terraform-azurerm-key-vault"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "platformAutomerge": false
+    }
+  ]
+}


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-31414

### Change description

- Add preset to update CPP Terraform Key Vault Module that can be extended within renovate configurations for individual repositories

### Testing done

I tested this rule within the key vault repository first.
No PR created as this wasn't within the configured Renovate schedule 7-11 AM but a link to renovate logs and relevant log fragments which confirm it is working as expected can be seen here: https://github.com/hmcts/cpp-terraform-azurerm-key-vault/pull/36

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
