### PR TITLE
Add matchPackages filter to jenkins-library package rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: renovate
+
+RENOVATE_CONFIG_FILE ?= $(PWD)/renovate-config.json
+RENOVATE_IMAGE := renovate/renovate:latest
+
+renovate:
+	docker run --rm \
+		-v "$(RENOVATE_CONFIG_FILE):/usr/src/app/renovate-config.json" \
+		-e RENOVATE_CONFIG_FILE="/usr/src/app/renovate-config.json" \
+		-e LOG_LEVEL="debug" \
+		$(RENOVATE_IMAGE) \
+		renovate-config-validator --strict /usr/src/app/renovate-config.json

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Global renovate configuration is contained within this repository, use this to i
 | `./renovate/global.json` | Deprecated, use ./renovate-config.json instead|
 | `./renovate/cpp-terraform-azurerm-key-vault.json` | This is a Terraform module specific Renovate preset, use it to keep this Terraform up to date within your consuming repository. It will automatically raise and approve PRs (which will be merge if auto-merge is on) for `patch` and `minor` versions, will raise PRs requiring human review for `major` versions.
 
+## Local Renovate validation
+
+Use following Make target to validate new Renovate config/preset, this allows you to catch typos and other simple problems before you merge your changes and Renovate scan rolls around which can take a while.  
+Note: validation may fail due to suggested config migration but this is not an indication it will not work, it just suggests we should update the configuration to more recent.
+
+```bash
+RENOVATE_CONFIG_FILE=<path-to-renovate-file> make renovate
+```
+
 ### Adding presets for Terraform modules
 
 Please refer to [this readme](./documentation/adding-presets-for-modules.md) regarding adding Renovate presets for more Terraform modules.

--- a/renovate/cnp-jenkins-library.json
+++ b/renovate/cnp-jenkins-library.json
@@ -3,7 +3,7 @@
   "packageRules": [
     {
       "matchDatasources": ["github-tags"],
-      "matchPackages": ["hmcts/cnp-jenkins-library"],
+      "matchPackageNames": ["hmcts/cnp-jenkins-library"],
       "matchUpdateTypes": [
         "minor",
         "patch"
@@ -13,7 +13,7 @@
     },
     {
       "matchDatasources": ["github-tags"],
-      "matchPackages": ["hmcts/cnp-jenkins-library"],
+      "matchPackageNames": ["hmcts/cnp-jenkins-library"],
       "matchUpdateTypes": [
         "major"
       ],

--- a/renovate/cnp-jenkins-library.json
+++ b/renovate/cnp-jenkins-library.json
@@ -2,6 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
+      "matchDatasources": ["github-tags"],
+      "matchPackages": ["hmcts/cnp-jenkins-library"],
       "matchUpdateTypes": [
         "minor",
         "patch"
@@ -10,6 +12,8 @@
       "automergeType": "pr"
     },
     {
+      "matchDatasources": ["github-tags"],
+      "matchPackages": ["hmcts/cnp-jenkins-library"],
       "matchUpdateTypes": [
         "major"
       ],


### PR DESCRIPTION

### Change description

- Add matchPackages filter to jenkins-library package rules so this preset does not unexpectedly enable automerge on all other dependencies.
This could happen, for example when a repository renovate configuration has no other `packageRules` defined and no other presets extended with `packageRules` which could override the ones in jenkins-library preset.

- Also add simple make target for validating the config against a self-hosted Renovate docker container, this helps catch various simple typos and errors before merging all the changes and getting Mend.IO Renovate scan to roll around.

### Testing done

-

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
