### PR TITLE
Deprecate preset file for CNP Jenkins Library and move the config to global configuration available by default instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ Global renovate configuration is contained within this repository, use this to i
 
 | Config file | Description |
 |---|---|
-| `./renovate-config.json` | Configures the basic renovate settings such as the schedule time and timezone. It also configures helm dependency manager, package rules for `Flyway` dependency and some host matching rules for helm dependencies. |
+| `./renovate-config.json` | Configures the basic renovate settings such as the schedule time and timezone. It also configures helm dependency manager, package rules for `Flyway` and `cnp-jenkins-library` dependencies, and some host matching rules for helm dependencies. |
 | `./renovate.json` | One of the default configurations available for use in your repository.  It combines settings in `renovate-config.json` with `automerge-all.json` - this means it will automatically raise PRs and auto-approve them via `renovate-approve` bots, if you have auto-merge enabled in your repository this means dependencies will always get updated automatically with no human review if the pipeline checks have passed.|
 | `./renovate/automerge-all.json` | Renovate preset for automatic raising and approving of dependency update PRs, it is not `patch/minor/major` limited and as described above might cause automatic dependency updates **so use wisely**.|
 | `./renovate/automerge-minor.json` | Renovate preset for automatic raising and approving of only the `patch` and `minor` version update PRs of the dependencies, this is a safer alternative to `automerge-all.json`.|
 | `./renovate/flux.json` | This preset is specific to `hmcts/cnp-flux-config` and `hmcts/sds-flux-config`, used to configure updates of specific dependencies in these repositories.
 | `./renovate/global.json` | Deprecated, use ./renovate-config.json instead|
+| `./renovate/cnp-jenkins-library.json` | Deprecated. Its configuration has moved to the global `./renovate-config.json` default. |
 | `./renovate/cpp-terraform-azurerm-key-vault.json` | This is a Terraform module specific Renovate preset, use it to keep this Terraform up to date within your consuming repository. It will automatically raise and approve PRs (which will be merge if auto-merge is on) for `patch` and `minor` versions, will raise PRs requiring human review for `major` versions.
+
+The base configuration also detects `@Library` declarations in `Jenkinsfile_*` files and updates `hmcts/cnp-jenkins-library` from GitHub tags. Patch and minor releases are set to automerge; major releases require review.
 
 ## Local Renovate validation
 

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -24,9 +24,52 @@
   "packageRules": [
     {
       "groupName": "flyway",
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "flyway"
       ]
+    },
+    {
+      "matchDatasources": [
+        "github-tags"
+      ],
+      "matchPackageNames": [
+        "hmcts/cnp-jenkins-library"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "matchDatasources": [
+        "github-tags"
+      ],
+      "matchPackageNames": [
+        "hmcts/cnp-jenkins-library"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false,
+      "platformAutomerge": false
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track @Library versions in Jenkinsfiles via GitHub tags",
+      "managerFilePatterns": [
+        "/^Jenkinsfile_.*$/"
+      ],
+      "matchStrings": [
+        "@Library\\(\\s*(?:value\\s*=\\s*)?[\"'](?<depName>[^@\"']+)@(?<currentValue>[^\"']+)[\"'](?:\\s*,\\s*changelog\\s*=\\s*(?:true|false))?\\s*\\)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "packageNameTemplate": "hmcts/cnp-jenkins-library",
+      "depNameTemplate": "Jenkins-{{{depName}}}",
+      "versioningTemplate": "semver"
     }
   ],
   "hostRules": [


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-34194

### Change description

Deprecate cnp-jenkins-library preset and move this into the global config instead so all repos will track jenkins library version by default as long as they have set the version in the Jenkins file.

### Testing done

Can only test once this has been merged - will do it against a toffee recipe service or something like that.
Deprecation way should ensure renovate won't break and I will move each repo one by one after I verify all is ok, there is about 30 repos to update from what I can see in the github search.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
